### PR TITLE
Fixes to bCSTP iteration

### DIFF
--- a/meet/spatfilt.py
+++ b/meet/spatfilt.py
@@ -266,10 +266,11 @@ def bCSTP(trials1, trials2, num_iter=30, s_keep=2, t_keep=2,
         'trials2')
     if num_iter < 10:
         raise ValueError('At least 10 iterations must be done.')
-    t_keep = _np.min([_np.hstack([[int(t_keep)] * 5,
-        _np.arange(6, num_iter+1, 1)])[::-1], [int(n_dp1)]*num_iter],0)
-    s_keep = _np.min([_np.hstack([[int(s_keep)] * 5,
-        _np.arange(6, num_iter+1, 1)])[::-1], [int(n_ch1)]*num_iter],0)
+    t_keep = _np.hstack([[int(t_keep)] * 5,
+        _np.linspace(6, n_dp1, num_iter-5).astype(int)])[::-1]
+    s_keep = _np.hstack([[int(s_keep)] * 5,
+        _np.linspace(6, n_ch1, num_iter-5).astype(int)])[::-1]
+
     # initialize output lists
     W = []
     V = [_np.identity(n_dp1, dtype=trials1.dtype)]


### PR DESCRIPTION
When performing bCSTP iterations, components are steadily dropped. The
logic behind the number of components to keep contains a flaw.

On the first iteration, the temporal filter is initialized to the
identity matrix (line 275). The intent here is to disable temporal
filtering during the first iteration. Therefore, no components should be
dropped at this stage.

Consider the following scenatio:

```
num_iter = 30 # 30 iterations
t_keep = 4    # Keep 4 temporal components in the end
n_dp1 = 50    # Epochs have 50 time samples
```

Then, the logic that calculates the number of components to keep at each
stage (line 269) computes the following vector:

```
[30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19, 18, 17, 16, 15, 14,
 13, 12, 11, 10,  9,  8,  7,  6,  4,  4,  4,  4,  4]
```

At the first iteration, only 30 of the possible 100 components are used.
This means the bCSTP filter will on this iteration only keep the first
30 time samples and drop the rest.

In this PR, I propose to change the logic to produce the following:

```
[50, 48, 46, 44, 42, 40, 39, 37, 35, 33, 31, 29, 28, 26, 24, 22, 20,
 18, 17, 15, 13, 11,  9,  7,  6,  4,  4,  4,  4,  4]
```

Now, at the first iteration, all components are used and components are
gradually dropped.
